### PR TITLE
merge latest upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ npm install --save-dev webpack-bundle-tracker
 ```javascript
 var BundleTracker  = require('webpack-bundle-tracker');
 module.exports = {
-        context: __dirname,
+    context: __dirname,
     entry: {
       app: ['./app']
     },
-    
+
     output: {
         path: require("path").resolve('./assets/bundles/'),
         filename: "[name]-[hash].js",
         publicPath: 'http://localhost:3000/assets/bundles/',
     },
-    
+
     plugins: [
       new BundleTracker({path: __dirname, filename: './assets/webpack-stats.json'})
     ]
@@ -67,7 +67,7 @@ And errors will look like,
 {
   "status": "error",
   "file": "/path/to/file/that/caused/the/error",
-  "error": "ErrorName", 
+  "error": "ErrorName",
   "message": "ErrorMessage"
 }
 ```
@@ -98,3 +98,12 @@ By default, the output JSON will not be indented. To increase readability, you c
 option to make the output legible. By default it is off. The value that is set here will be directly
 passed to the `space` parameter in `JSON.stringify`. More information can be found here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+
+<br>
+
+#### Bundle Tracker Options
+
+* `filename` - Name of the bundle tracker JSON file.
+* `logTime` - Optional boolean property to output `startTime` and `endTime` in bundle tracker file.
+* `path` - Optional bundle tracker output path.
+* `publicPath` - Optional property to override `output.publicPath`.

--- a/index.js
+++ b/index.js
@@ -58,8 +58,9 @@ Plugin.prototype.apply = function(compiler) {
       stats.compilation.chunks.map(function(chunk){
         var files = chunk.files.map(function(file){
           var F = {name: file};
-          if (compiler.options.output.publicPath) {
-            F.publicPath= compiler.options.output.publicPath + file;
+          var publicPath = self.options.publicPath || compiler.options.output.publicPath;
+          if (publicPath) {
+            F.publicPath = publicPath + file;
           }
           if (compiler.options.output.path) {
             F.path = path.join(compiler.options.output.path, file);
@@ -86,8 +87,9 @@ Plugin.prototype.apply = function(compiler) {
 Plugin.prototype.writeOutput = function(compiler, contents) {
   var outputDir = this.options.path || '.';
   var outputFilename = path.join(outputDir, this.options.filename || DEFAULT_OUTPUT_FILENAME);
-  if (compiler.options.output.publicPath) {
-    contents.publicPath = compiler.options.output.publicPath;
+  var publicPath = this.options.publicPath || compiler.options.output.publicPath;
+  if (publicPath) {
+    contents.publicPath = publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
 

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ Plugin.prototype.apply = function(compiler) {
       compiler.hooks.compile.tap(plugin, compile);
       compiler.hooks.done.tap(plugin, done);
     } else {
-      compiler.plugin('compilation', compilation);
+      compiler.plugin('compilation', _compilation);
       compiler.plugin('compile', compile);
       compiler.plugin('done', done);
     }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var DEFAULT_LOG_TIME = false;
 
 
 function Plugin(options) {
+  this.contents = {};
   this.options = options || {};
   this.options.filename = this.options.filename || DEFAULT_OUTPUT_FILENAME;
   if (this.options.logTime === undefined) {
@@ -23,7 +24,7 @@ Plugin.prototype.apply = function(compiler) {
       compilation.plugin('failed-module', function(fail){
         var output = {
           status: 'error',
-          error: fail.error.name
+          error: fail.error.name || 'unknown-error'
         };
         if (fail.error.module !== undefined) {
           output.file = fail.error.module.userRequest;
@@ -44,7 +45,7 @@ Plugin.prototype.apply = function(compiler) {
         var error = stats.compilation.errors[0];
         self.writeOutput(compiler, {
           status: 'error',
-          error: error['name'],
+          error: error['name'] || 'unknown-error',
           message: stripAnsi(error['message'])
         });
         return;
@@ -86,7 +87,12 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
     contents.publicPath = compiler.options.output.publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
-  fs.writeFileSync(outputFilename, JSON.stringify(contents, null, this.options.indent));
+
+  this.contents = Object.assign(this.contents, contents);
+  fs.writeFileSync(
+    outputFilename,
+    JSON.stringify(this.contents, null, this.options.indent)
+  );
 };
 
 module.exports = Plugin;

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ Plugin.prototype.apply = function(compiler) {
         }
         if (fail.error.error !== undefined) {
           output.message = stripAnsi(fail.error.error.codeFrame);
+        } else {
+          output.message = '';
         }
         self.writeOutput(compiler, output);
       });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var stripAnsi = require('strip-ansi');
 var mkdirp = require('mkdirp');
+var extend = require('deep-extend');
 
 var assets = {};
 var DEFAULT_OUTPUT_FILENAME = 'webpack-stats.json';
@@ -88,7 +89,7 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
   }
   mkdirp.sync(path.dirname(outputFilename));
 
-  this.contents = Object.assign(this.contents, contents);
+  this.contents = extend(this.contents, contents);
   fs.writeFileSync(
     outputFilename,
     JSON.stringify(this.contents, null, this.options.indent)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
+    "deep-extend": "^0.4.1",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.6.0",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.4.0-beta",
+  "version": "0.4.1-beta",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.0.93",
+  "version": "0.1.0",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.3.0",
+  "version": "0.4.0-beta",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-tracker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Spits out some stats about webpack compilation process to a file",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION

This adds webpack 4 support and removes one source of API deprecation warnings from the Kolibri build process

